### PR TITLE
feat: have pyaxp return a Spark StructType for schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "pyaxp"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "arrow",
  "encoding_rs",
@@ -2919,7 +2919,7 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaxp-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "clap",
  "encoding_rs",
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "yaxp-common"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "arrow",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 
 [workspace.package]
 name = "yaxp"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 authors = ["Jeroen <jeroen@flexworks.eu>"]
 description = "Yet Another XML Parser"

--- a/crates/pyaxp/Cargo.toml
+++ b/crates/pyaxp/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "pyaxp"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.23.3", features = ["extension-module", "serde"] }
-yaxp-common = { path = "../yaxp-common", version = "0.1.15" }
+yaxp-common = { path = "../yaxp-common", version = "0.1.16" }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 arrow = "54.1.0"

--- a/crates/pyaxp/README.md
+++ b/crates/pyaxp/README.md
@@ -45,43 +45,52 @@ Installed 1 package in 2ms
 ```python
 Python 3.12.3 (main, Apr 15 2024, 17:43:11) [Clang 17.0.6 ] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
->>> import json
->>>
 >>> from pyspark.sql import SparkSession
->>> from pyspark.sql.types import (
-...     StructType, StructField, StringType, TimestampType, DateType, DecimalType, IntegerType
-... )
->>> from pyaxp import parse_xsd
->>>
->>> from datetime import datetime, date
->>> from decimal import Decimal
->>>
->>> data = [
-...     ("A1", "B1", "C1", "D1", datetime(2024, 2, 1, 10, 30, 0), date(2024, 2, 1), date(2024, 1, 31),
-...      "E1", "F1", "G1", "H1", Decimal("123456789012345678.1234567"), "I1", "J1", "K1", "L1",
-...      date(2024, 2, 1), "M1", "N1", Decimal("100"), 10),
+... from pyaxp import parse_xsd
+...
+... from datetime import datetime, date
+... from decimal import Decimal
+...
+... data = [
+    ...     ("A1", "B1", "C1", "D1", datetime(2024, 2, 1, 10, 30, 0), date(2024, 2, 1), date(2024, 1, 31),
+             ...      "E1", "F1", "G1", "H1", Decimal("123456789012345678.1234567"), "I1", "J1", "K1", "L1",
+    ...      date(2024, 2, 1), "M1", "N1", Decimal("100"), 10),
 ...
 ...     ("A2", "B2", "C2", None, datetime(2024, 2, 1, 11, 0, 0), None, date(2024, 1, 30),
-...      "E2", None, "G2", "H2", None, "I2", "J2", "K2", "L2",
+         ...      "E2", None, "G2", "H2", None, "I2", "J2", "K2", "L2",
 ...      date(2024, 2, 2), "M2", "N2", Decimal("200"), 20),
 ...
 ...     ("A3", "B3", "C3", "D3", datetime(2024, 2, 1, 12, 15, 0), date(2024, 2, 3), None,
-...      "E3", "F3", None, "H3", Decimal("98765432109876543.7654321"), "I3", None, "K3", "L3",
+         ...      "E3", "F3", None, "H3", Decimal("98765432109876543.7654321"), "I3", None, "K3", "L3",
 ...      date(2024, 2, 3), "M3", "N3", None, None)
 ... ]
->>>
->>>
->>> spark = SparkSession.builder.master("local").appName("Test Data").getOrCreate()
-25/02/01 16:27:30 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
+...
+...
+... spark = SparkSession.builder.master("local").appName("Test Data").getOrCreate()
+... schema = parse_xsd("example.xsd", "spark")
+... df = spark.createDataFrame(data, schema=schema)
+...
+25/02/08 13:22:01 WARN Utils: Your hostname, Jeroens-MacBook-Air.local resolves to a loopback address: 127.0.0.1; using 192.168.69.217 instead (on interface en0)
+25/02/08 13:22:01 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
 Setting default log level to "WARN".
 To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
-25/02/01 16:27:30 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
->>> 25/02/01 16:27:42 WARN GarbageCollectionMetrics: To enable non-built-in garbage collector(s) List(G1 Concurrent GC), users should configure it(them) to spark.eventLog.gcMetrics.youngGenerationGarbageCollectors or spark.eventLog.gcMetrics.oldGenerationGarbageCollectors
+25/02/08 13:22:01 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
+>>> type(schema)
+<class 'pyspark.sql.types.StructType'>
+>>> sch25/02/08 13:22:15 WARN GarbageCollectionMetrics: To enable non-built-in garbage collector(s) List(G1 Concurrent GC), users should configure it(them) to spark.eventLog.gcMetrics.youngGenerationGarbageCollectors or spark.eventLog.gcMetrics.oldGenerationGarbageCollectors
+>>> schema
+StructType([StructField('Field1', StringType(), False), StructField('Field2', StringType(), False), StructField('Field3', StringType(), False), StructField('Field4', StringType(), True), StructField('Field5', TimestampType(), False), StructField('Field6', DateType(), True), StructField('Field7', DateType(), True), StructField('Field8', StringType(), False), StructField('Field9', StringType(), True), StructField('Field10', StringType(), True), StructField('Field11', StringType(), True), StructField('Field12', DecimalType(25,7), True), StructField('Field13', StringType(), True), StructField('Field14', StringType(), True), StructField('Field15', StringType(), False), StructField('Field16', StringType(), True), StructField('Field17', DateType(), False), StructField('Field18', StringType(), True), StructField('Field19', StringType(), True), StructField('Field20', DecimalType(10,0), True), StructField('Field21', IntegerType(), True)])
+>>> df
+DataFrame[Field1: string, Field2: string, Field3: string, Field4: string, Field5: timestamp, Field6: date, Field7: date, Field8: string, Field9: string, Field10: string, Field11: string, Field12: decimal(25,7), Field13: string, Field14: string, Field15: string, Field16: string, Field17: date, Field18: string, Field19: string, Field20: decimal(10,0), Field21: int]
+>>> df.show()
++------+------+------+------+-------------------+----------+----------+------+------+-------+-------+--------------------+-------+-------+-------+-------+----------+-------+-------+-------+-------+
+|Field1|Field2|Field3|Field4|             Field5|    Field6|    Field7|Field8|Field9|Field10|Field11|             Field12|Field13|Field14|Field15|Field16|   Field17|Field18|Field19|Field20|Field21|
++------+------+------+------+-------------------+----------+----------+------+------+-------+-------+--------------------+-------+-------+-------+-------+----------+-------+-------+-------+-------+
+|    A1|    B1|    C1|    D1|2024-02-01 10:30:00|2024-02-01|2024-01-31|    E1|    F1|     G1|     H1|12345678901234567...|     I1|     J1|     K1|     L1|2024-02-01|     M1|     N1|    100|     10|
+|    A2|    B2|    C2|  NULL|2024-02-01 11:00:00|      NULL|2024-01-30|    E2|  NULL|     G2|     H2|                NULL|     I2|     J2|     K2|     L2|2024-02-02|     M2|     N2|    200|     20|
+|    A3|    B3|    C3|    D3|2024-02-01 12:15:00|2024-02-03|      NULL|    E3|    F3|   NULL|     H3|98765432109876543...|     I3|   NULL|     K3|     L3|2024-02-03|     M3|     N3|   NULL|   NULL|
++------+------+------+------+-------------------+----------+----------+------+------+-------+-------+--------------------+-------+-------+-------+-------+----------+-------+-------+-------+-------+
 
->>> j = parse_xsd("example.xsd", format="spark")
->>> spark_schema = StructType.fromJson(json.loads(j))
->>> df = spark.createDataFrame(data, schema=spark_schema)
->>>
 >>> df.printSchema()
 root
  |-- Field1: string (nullable = false)

--- a/crates/pyaxp/src/lib.rs
+++ b/crates/pyaxp/src/lib.rs
@@ -306,8 +306,11 @@ fn parse_xsd(
                 },
                 SchemaFormat::Spark => match schema.to_spark() {
                     Ok(spark) => {
-                        println!("yes, SPARK!");
-                        Ok(spark.into_pyobject(py)?.into())
+                        let pyspark_module = PyModule::import(py, "pyspark.sql.types")?;
+                        let pyspark_struct_type = pyspark_module.getattr("StructType")?;
+                        let dict_schema = spark.into_pyobject(py)?;
+                        let py_struct_type = pyspark_struct_type.getattr("fromJson")?.call1((dict_schema,))?;
+                        Ok(py_struct_type.into())
                     }
                     Err(e) => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
                         "{}",

--- a/crates/pyaxp/tests/test_spark.py
+++ b/crates/pyaxp/tests/test_spark.py
@@ -1,5 +1,3 @@
-import json
-
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     StructType, StructField, StringType, TimestampType, DateType, DecimalType, IntegerType
@@ -26,8 +24,7 @@ data = [
 
 spark = SparkSession.builder.master("local").appName("Test Data").getOrCreate()
 schema = parse_xsd("example.xsd", "spark")
-spark_schema = StructType.fromJson(schema)
-df = spark.createDataFrame(data, schema=spark_schema)
+df = spark.createDataFrame(data, schema=schema)
 
 
 def test_parse_schema():

--- a/crates/yaxp-cli/Cargo.toml
+++ b/crates/yaxp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaxp-cli"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 authors = ["Jeroen <jeroen@flexworks.eu>"]
 description = "<yaxp-cli ⚡> Yet Another XML Parser CLI"
@@ -10,6 +10,6 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
-yaxp-common = { path = "../yaxp-common", version = "0.1.15" }
+yaxp-common = { path = "../yaxp-common", version = "0.1.16" }
 serde = { version = "1.0.217", features = ["derive"] }
 encoding_rs = "0.8.35"

--- a/crates/yaxp-common/Cargo.toml
+++ b/crates/yaxp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaxp-common"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 authors = ["Jeroen <jeroen@flexworks.eu>"]
 description = "<yaxp-cli ⚡> Yet Another XML Parser"


### PR DESCRIPTION
- change spark schema type from dict to StructType

changing this:
```python
import json
from pyaxp import parse_xsd
from pyspark.sql.types import StructType
schema = parse_xsd("example.xsd", "spark")
spark_schema = StructType.fromJson(schema)
```

to this:
```python
from pyaxp import parse_xsd
spark_schema = parse_xsd("example.xsd", "spark")
```